### PR TITLE
Error handling for no custom directory

### DIFF
--- a/lib/aphorism.rb
+++ b/lib/aphorism.rb
@@ -21,6 +21,7 @@ module Aphorism
 
     def custom_aphorisms
       custom_path = File.join(Dir.home, '.aphorism')
+      return unless File.directory?(custom_path)
       custom_files = Dir.entries(custom_path) - ['.', '..']
       custom_aphorisms = []
       custom_files.each do |file|

--- a/lib/aphorism.rb
+++ b/lib/aphorism.rb
@@ -22,7 +22,7 @@ module Aphorism
     def custom_aphorisms
       custom_path = File.join(Dir.home, '.aphorism')
       return unless File.directory?(custom_path)
-      custom_files = Dir.entries(custom_path) - ['.', '..']
+      custom_files = Dir.entries(custom_path).select! { |file| file.include?(".txt")}
       custom_aphorisms = []
       custom_files.each do |file|
         custom_aphorisms += IO.read(File.join(custom_path, file)).split("\n%\n")


### PR DESCRIPTION
returns if the custom directory doesn't exist and skips non-.txt files.