### PR TITLE
Returns an empty array if custom dir doesn't exist

### DIFF
--- a/lib/aphorism.rb
+++ b/lib/aphorism.rb
@@ -21,7 +21,7 @@ module Aphorism
 
     def custom_aphorisms
       custom_path = File.join(Dir.home, '.aphorism')
-      return unless File.directory?(custom_path)
+      return [] unless File.directory?(custom_path)
 
       custom_files = Dir.entries(custom_path).select! do |file|
         file.include?('.txt')


### PR DESCRIPTION
Combining the existing array with a nil if the custom dir doesn't exist won't work, should have returned a comparable type